### PR TITLE
Make nesting work for newly added child observables

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,15 @@ var blackList = {
     "_type": "_type is reserved key of observ-struct.\n",
     "_version": "_version is reserved key of observ-struct.\n"
 }
+
+function checkBlackList(key) {
+    if (blackList.hasOwnProperty(key)) {
+        throw new Error("cannot create an observ-struct " +
+            "with a key named '" + key + "'.\n" +
+            blackList[key]);
+    }
+}
+
 var NO_TRANSACTION = {}
 
 function setNonEnumerable(object, key, value) {
@@ -36,12 +45,7 @@ function ObservStruct(struct) {
     var nestedTransaction = NO_TRANSACTION
 
     keys.forEach(function (key) {
-        if (blackList.hasOwnProperty(key)) {
-            throw new Error("cannot create an observ-struct " +
-                "with a key named '" + key + "'.\n" +
-                blackList[key]);
-        }
-
+        checkBlackList(key)
         var observ = struct[key]
         initialState[key] = typeof observ === "function" ?
             observ() : observ
@@ -78,6 +82,13 @@ function ObservStruct(struct) {
         }
 
         var newState = extend(value)
+        Object.keys(newState).map(function(key){
+            checkBlackList(key)
+            if (typeof newState[key] === "function") {
+                obs[key] = newState[key]
+                newState[key] = newState[key]()
+            }
+        })
         setNonEnumerable(newState, "_diff", value)
         _set(newState)
     }

--- a/test/index.js
+++ b/test/index.js
@@ -236,3 +236,30 @@ test("_diff is correct with 2way bind", function t(assert) {
 
     assert.end()
 })
+
+test("nested observ-structs are always flattened", function t(assert) {
+    var obs = ObservHash({
+        foo: ObservHash({
+            bar: Observ(8)
+        })
+    })
+
+    assert.equal(obs().foo.bar, 8)
+    assert.equal(obs.foo().bar, 8)
+    assert.equal(obs.foo.bar(), 8)
+
+    var v = obs()
+    v.baz = ObservHash({
+        quux: Observ(23)
+    })
+    obs.set(v)
+
+    assert.equal(obs().baz.quux, 23)
+    assert.equal(obs.baz().quux, 23)
+    assert.equal(obs.baz.quux(), 23)
+
+    console.log(obs())
+
+    assert.end()
+
+})


### PR DESCRIPTION
Suppose you create an `ObservStruct` and then decide to add more observable keys to it at some later point. Well, since all the nice magic only happens on initialization, that doesn't really work. For example, if you do something like:

```
foo = Observ("foo")
bar = Observ("bar")
baz = ObservStruct({ foo: foo })
baz.set(extend(baz(), { bar: bar }))
```

then `baz()` would return `{ foo: "foo", bar: [Function: observable]  }` rather than `{ foo: "foo", bar: "bar" }`; and `baz.bar` would also remain `undefined` rather than becoming a proper reference to `bar`.

That behavior was getting in my way -- I'm putting together a simple observable key-value store for individually observable models, to serve as a state container for my app which involves a lot of user-created instances of said models -- so I had a stab at fixing it. Let me know what you think?
